### PR TITLE
Bump commons-io from LATEST to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,14 +73,14 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>LATEST</version>
+			<version>2.7</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
+			<version>2.7</version>
 		</dependency>
 
 


### PR DESCRIPTION
Bumps commons-io from LATEST to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>